### PR TITLE
Fix npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "bin": "./dist/index.js",
   "scripts": {
-    "build": "rm -rf ./dist/* && ./node_modules/typescript/bin/tsc",
-    "test": "./node_modules/.bin/jest",
-    "gnerate": "./node_modules/typescript/bin/tsc & node ./dist/index.js --config=example/gnerate.config.js"
+    "build": "rm -rf ./dist/* && tsc",
+    "test": "jest",
+    "gnerate": "tsc & node ./dist/index.js --config=example/gnerate.config.js"
   },
   "keywords": [
     "gnerate",


### PR DESCRIPTION
Hello,

I am proposing the below fix about **npm scripts**.

In this PR, I am referencing the dependencies (**typescript** and **jest**) directly instead of accessing them using node_modules/** relative paths which is not the clean way since these paths may change by their providers at any time and that would break these npm scripts!

Thanks for your review =)